### PR TITLE
Ignored GCC 10 warnings

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,7 @@
 libicd-wireguard (0.1.2) unstable; urgency=medium
+  * Compatibility with GCC 10
+ -- Blagovest Petrov <blagovest@petrovs.info> Fri, 2 Dec 2022 16:22:08 +0300
+libicd-wireguard (0.1.2) unstable; urgency=medium
 
   * Support config override
 

--- a/debian/rules
+++ b/debian/rules
@@ -11,7 +11,7 @@ endif
 DEB_CONFIGURE_EXTRA_FLAGS = --prefix=/usr --sysconfdir=/etc --disable-static $(confflags)
 
 # default flags
-CFLAGS += -g -O2
+CFLAGS += -g -O2 -Wno-error=stringop-overflow
 
 override_dh_auto_install:
 	dh_auto_install --destdir=debian/tmp


### PR DESCRIPTION
Ignored GCC warning for possible buffer overflow.

```
../libtool: line 1747: warning: setlocale: LC_MESSAGES: cannot change locale (en_GB)
libtool: compile:  gcc -DHAVE_CONFIG_H -I. -I.. -I/usr/include/glib-2.0 -I/usr/lib/x86_64-linux-gnu/glib-2.0/include -pthread -I/usr/include/gconf/2 -I/usr/include/dbus-1.0 -I/usr/lib/x86_64-linux-gnu/dbus-1.0/include -I/usr/include/libmount -I/usr/include/blkid -I/usr/include/glib-2.0 -I/usr/lib/x86_64-linux-gnu/glib-2.0/include -I/usr/include/glib-2.0 -I/usr/lib/x86_64-linux-gnu/glib-2.0/include -I/usr/include/icd -I/usr/include/icd -Wdate-time -D_FORTIFY_SOURCE=2 -g -O2 -ffile-prefix-map=/root/packages/libicd-wireguard=. -fstack-protector-strong -Wformat -Werror=format-security -g -O2 -Wall -Werror -Wmissing-prototypes -include config.h -c libicd_wireguard_config.c  -fPIC -DPIC -o .libs/libicd_wireguard_config.o
../libtool: line 1747: warning: setlocale: LC_MESSAGES: cannot change locale (en_GB)
In file included from /usr/include/string.h:495,
                 from /usr/include/glib-2.0/glib/gslice.h:26,
                 from /usr/include/glib-2.0/glib.h:79,
                 from libicd_wireguard_config.c:24:
In function 'strncat',
    inlined from 'generate_config' at libicd_wireguard_config.c:163:2:
/usr/include/x86_64-linux-gnu/bits/string_fortified.h:136:10: error: '__builtin___strncat_chk' specified bound depends on the length of the source argument [-Werror=stringop-overflow=]
  136 |   return __builtin___strncat_chk (__dest, __src, __len, __bos (__dest));
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
libicd_wireguard_config.c: In function 'generate_config':
libicd_wireguard_config.c:163:2: note: length computed here
  163 |  strncat(config, privatekey, strlen(privatekey));
      |  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
In file included from /usr/include/string.h:495,
                 from /usr/include/glib-2.0/glib/gslice.h:26,
                 from /usr/include/glib-2.0/glib.h:79,
                 from libicd_wireguard_config.c:24:
In function 'strncat',
    inlined from 'generate_config' at libicd_wireguard_config.c:165:2:
/usr/include/x86_64-linux-gnu/bits/string_fortified.h:136:10: error: '__builtin___strncat_chk' specified bound depends on the length of the source argument [-Werror=stringop-overflow=]
  136 |   return __builtin___strncat_chk (__dest, __src, __len, __bos (__dest));
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
libicd_wireguard_config.c: In function 'generate_config':
libicd_wireguard_config.c:165:2: note: length computed here
  165 |  strncat(config, address, strlen(address));
      |  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
In file included from /usr/include/string.h:495,
                 from /usr/include/glib-2.0/glib/gslice.h:26,
                 from /usr/include/glib-2.0/glib.h:79,
                 from libicd_wireguard_config.c:24:
In function 'strncat',
    inlined from 'generate_config' at libicd_wireguard_config.c:168:3:
/usr/include/x86_64-linux-gnu/bits/string_fortified.h:136:10: error: '__builtin___strncat_chk' specified bound depends on the length of the source argument [-Werror=stringop-overflow=]
  136 |   return __builtin___strncat_chk (__dest, __src, __len, __bos (__dest));
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
libicd_wireguard_config.c: In function 'generate_config':
libicd_wireguard_config.c:168:3: note: length computed here
  168 |   strncat(config, dns, strlen(dns));
      |   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
In file included from /usr/include/string.h:495,
                 from /usr/include/glib-2.0/glib/gslice.h:26,
                 from /usr/include/glib-2.0/glib.h:79,
                 from libicd_wireguard_config.c:24:
In function 'strncat',
    inlined from 'generate_config' at libicd_wireguard_config.c:200:3:
/usr/include/x86_64-linux-gnu/bits/string_fortified.h:136:10: error: '__builtin___strncat_chk' specified bound depends on the length of the source argument [-Werror=stringop-overflow=]
  136 |   return __builtin___strncat_chk (__dest, __src, __len, __bos (__dest));
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
libicd_wireguard_config.c: In function 'generate_config':
libicd_wireguard_config.c:200:3: note: length computed here
  200 |   strncat(config, pubkey, strlen(pubkey));
      |   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
In file included from /usr/include/string.h:495,
                 from /usr/include/glib-2.0/glib/gslice.h:26,
                 from /usr/include/glib-2.0/glib.h:79,
                 from libicd_wireguard_config.c:24:
In function 'strncat',
    inlined from 'generate_config' at libicd_wireguard_config.c:202:3:
/usr/include/x86_64-linux-gnu/bits/string_fortified.h:136:10: error: '__builtin___strncat_chk' specified bound depends on the length of the source argument [-Werror=stringop-overflow=]
  136 |   return __builtin___strncat_chk (__dest, __src, __len, __bos (__dest));
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
libicd_wireguard_config.c: In function 'generate_config':
libicd_wireguard_config.c:202:3: note: length computed here
  202 |   strncat(config, endpoint, strlen(endpoint));
      |   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
In file included from /usr/include/string.h:495,
                 from /usr/include/glib-2.0/glib/gslice.h:26,
                 from /usr/include/glib-2.0/glib.h:79,
                 from libicd_wireguard_config.c:24:
In function 'strncat',
    inlined from 'generate_config' at libicd_wireguard_config.c:204:3:
/usr/include/x86_64-linux-gnu/bits/string_fortified.h:136:10: error: '__builtin___strncat_chk' specified bound depends on the length of the source argument [-Werror=stringop-overflow=]
  136 |   return __builtin___strncat_chk (__dest, __src, __len, __bos (__dest));
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
libicd_wireguard_config.c: In function 'generate_config':
libicd_wireguard_config.c:204:3: note: length computed here
  204 |   strncat(config, peer_ips, strlen(peer_ips));
      |   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
cc1: all warnings being treated as errors
make[3]: *** [Makefile:492: libicd_wireguard_config.lo] Error 1
make[3]: *** Waiting for unfinished jobs....
make[3]: Leaving directory '/root/packages/libicd-wireguard/src'
make[2]: *** [Makefile:420: all-recursive] Error 1
make[2]: Leaving directory '/root/packages/libicd-wireguard'
make[1]: *** [Makefile:352: all] Error 2
make[1]: Leaving directory '/root/packages/libicd-wireguard'
dh_auto_build: error: make -j2 returned exit code 2
make: *** [debian/rules:25: build] Error 2
dpkg-buildpackage: error: debian/rules build subprocess returned exit status 2
root@maemo:~/packages/libicd-wireguard# cd ^C
root@maemo:~/packages/libicd-wireguard# cat debian/control 
Source: libicd-wireguard
```